### PR TITLE
Refactor/replace package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# fastify-auth0-verify
+# fastify-jwt-jwks
 
-[![Package Version](https://img.shields.io/npm/v/fastify-auth0-verify.svg)](https://npm.im/fastify-auth0-verify)
-[![ci](https://github.com/nearform/fastify-auth0-verify/actions/workflows/ci.yml/badge.svg)](https://github.com/nearform/fastify-auth0-verify/actions/workflows/ci.yml)
+[![Package Version](https://img.shields.io/npm/v/fastify-jwt-jwks.svg)](https://npm.im/fastify-jwt-jwks)
+[![ci](https://github.com/nearform/fastify-jwt-jwks/actions/workflows/ci.yml/badge.svg)](https://github.com/nearform/fastify-jwt-jwks/actions/workflows/ci.yml)
 
-Auth0 verification plugin for Fastify, internally uses [@fastify/jwt](https://www.npmjs.com/package/@fastify/jwt).
+JWT verification plugin for Fastify, internally uses [@fastify/jwt](https://www.npmjs.com/package/@fastify/jwt).
 
 ## Installation
 
 Just run:
 
 ```bash
-npm install fastify-auth0-verify --save
+npm install fastify-jwt-jwks --save
 ```
 
 ## Usage
@@ -41,7 +41,7 @@ Example:
 const fastify = require('fastify')
 const server = fastify()
 
-await server.register(require('fastify-auth0-verify'), {
+await server.register(require('fastify-jwt-jwks'), {
   jwksUrl: '<JWKS url>',
   audience: '<app audience>'
 })
@@ -57,10 +57,10 @@ server.listen(0, err => {
 })
 ```
 
-You can configure there to be more than one Auth0 API audiences:
+You can configure there to be more than one JWT API audience:
 
 ```js
-await server.register(require('fastify-auth0-verify'), {
+await server.register(require('fastify-jwt-jwks'), {
   jwksUrl: '<JWKS url>',
   audience: ['<app audience>', '<admin audience>']
 })
@@ -69,7 +69,7 @@ await server.register(require('fastify-auth0-verify'), {
 You can include [@fastify/jwt verify](https://github.com/fastify/fastify-jwt#verify) options:
 
 ```js
-await server.register(require('fastify-auth0-verify'), {
+await server.register(require('fastify-jwt-jwks'), {
   jwksUrl: '<JWKS url>',
   audience: ['<app audience>', '<admin audience>'],
   cache: true, // @fastify/jwt cache

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,5 +7,5 @@ A token must also be provided.
 ### Example
 
 ```sh
-node index.js --domain {auth0 domain} --token {auth0 id token}
+node index.js --jwksUrl {jwksUrl} --token {jwt token}
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ import { UserType, SignPayloadType } from '@fastify/jwt'
 
 import NodeCache from 'node-cache'
 
-export interface FastifyAuth0VerifyOptions {
+export interface FastifyJwtJwksOptions {
   /**
    * JSON Web Key Set url (JWKS).
    * The public endpoint returning the set of keys that contain amongst other things the keys needed to verify JSON Web Tokens (JWT)
@@ -58,8 +58,8 @@ export interface FastifyAuth0VerifyOptions {
   readonly formatUser?: (payload: SignPayloadType) => UserType
 }
 
-export interface Auth0Verify extends Pick<FastifyAuth0VerifyOptions, 'jwksUrl' | 'audience' | 'secret'> {
-  readonly verify: FastifyAuth0VerifyOptions & {
+export interface JwtJwks extends Pick<FastifyJwtJwksOptions, 'jwksUrl' | 'audience' | 'secret'> {
+  readonly verify: FastifyJwtJwksOptions & {
     readonly algorithms: readonly string[]
     readonly audience?: string | readonly string[]
   }
@@ -68,19 +68,19 @@ export interface Auth0Verify extends Pick<FastifyAuth0VerifyOptions, 'jwksUrl' |
 export type Authenticate = (request: FastifyRequest, reply: FastifyReply) => Promise<void>
 
 /**
- * Auth0 verification plugin for Fastify, internally uses @fastify/jwt and jsonwebtoken.
+ * JWT JWKS verification plugin for Fastify, internally uses @fastify/jwt and jsonwebtoken.
  */
-export const fastifyAuth0Verify: FastifyPluginCallback<FastifyAuth0VerifyOptions>
-export default fastifyAuth0Verify
+export const fastifyJwtJwks: FastifyPluginCallback<FastifyJwtJwksOptions>
+export default fastifyJwtJwks
 
 declare module 'fastify' {
   interface FastifyInstance {
     authenticate: Authenticate
-    auth0Verify: Auth0Verify
+    jwtJwks: JwtJwks
   }
 
   interface FastifyRequest {
-    auth0Verify: Auth0Verify
-    auth0VerifySecretsCache: Pick<NodeCache, 'get' | 'set' | 'close'>
+    jwtJwks: JwtJwks
+    jwtJwksSecretsCache: Pick<NodeCache, 'get' | 'set' | 'close'>
   }
 }

--- a/index.js
+++ b/index.js
@@ -180,17 +180,17 @@ async function authenticate(request, reply) {
   }
 }
 
-function fastifyAuth0Verify(instance, options, done) {
+function fastifyJwtJwks(instance, options, done) {
   try {
     // Check if secrets cache is wanted - Convert milliseconds to seconds and cache for a week by default
     const ttl = parseFloat('secretsTtl' in options ? options.secretsTtl : '604800000', 10) / 1e3
     delete options.secretsTtl
 
-    const auth0Options = verifyOptions(options)
+    const jwtJwksOptions = verifyOptions(options)
 
     // Setup @fastify/jwt
     instance.register(fastifyJwt, {
-      verify: auth0Options.verify,
+      verify: jwtJwksOptions.verify,
       cookie: options.cookie,
       secret: getSecret,
       jwtDecode: 'jwtDecode',
@@ -199,9 +199,9 @@ function fastifyAuth0Verify(instance, options, done) {
 
     // Setup our decorators
     instance.decorate('authenticate', authenticate)
-    instance.decorate('auth0Verify', auth0Options)
+    instance.decorate('auth0Verify', jwtJwksOptions)
     instance.decorateRequest('auth0Verify', {
-      getter: () => auth0Options
+      getter: () => jwtJwksOptions
     })
 
     const cache =
@@ -220,4 +220,4 @@ function fastifyAuth0Verify(instance, options, done) {
   }
 }
 
-module.exports = fastifyPlugin(fastifyAuth0Verify, { name: 'fastify-auth0-verify', fastify: '4.x' })
+module.exports = fastifyPlugin(fastifyJwtJwks, { name: 'fastify-jwt-jwks', fastify: '4.x' })

--- a/index.js
+++ b/index.js
@@ -149,13 +149,13 @@ function getSecret(request, reply, cb) {
     .then(decoded => {
       const { header } = decoded
 
-      // If the algorithm is not using RS256, the encryption key is Auth0 client secret
+      // If the algorithm is not using RS256, the encryption key is jwt client secret
       if (header.alg.startsWith('HS')) {
-        return cb(null, request.auth0Verify.secret)
+        return cb(null, request.jwtJwks.secret)
       }
 
       // If the algorithm is RS256, get the key remotely using a well-known URL containing a JWK set
-      getRemoteSecret(request.auth0Verify.jwksUrl, header.alg, header.kid, request.auth0VerifySecretsCache)
+      getRemoteSecret(request.jwtJwks.jwksUrl, header.alg, header.kid, request.jwtJwksSecretsCache)
         .then(key => cb(null, key))
         .catch(cb)
     })
@@ -199,8 +199,8 @@ function fastifyJwtJwks(instance, options, done) {
 
     // Setup our decorators
     instance.decorate('authenticate', authenticate)
-    instance.decorate('auth0Verify', jwtJwksOptions)
-    instance.decorateRequest('auth0Verify', {
+    instance.decorate('jwtJwks', jwtJwksOptions)
+    instance.decorateRequest('jwtJwks', {
       getter: () => jwtJwksOptions
     })
 
@@ -208,7 +208,7 @@ function fastifyJwtJwks(instance, options, done) {
       ttl > 0 ? new NodeCache({ stdTTL: ttl }) : { get: () => undefined, set: () => false, close: () => undefined }
 
     // Create a cache or a fake cache
-    instance.decorateRequest('auth0VerifySecretsCache', {
+    instance.decorateRequest('jwtJwksSecretsCache', {
       getter: () => cache
     })
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,43 +1,43 @@
 import Fastify from 'fastify'
-import fastifyAuth0Verify from '.'
+import fastifyJwtJwks from '.'
 import { expectAssignable, expectType } from 'tsd'
 import { DecodePayloadType, FastifyJwtDecodeOptions } from '@fastify/jwt'
 import fastifyJWT from '@fastify/jwt'
 
 const fastify = Fastify()
 
-fastify.register(fastifyAuth0Verify, {
+fastify.register(fastifyJwtJwks, {
   jwksUrl: '<JWKS url>',
-  issuer: '<auth0 issuer>',
-  audience: '<auth0 app audience>'
+  issuer: '<jwt issuer>',
+  audience: '<jwt app audience>'
 })
-fastify.register(fastifyAuth0Verify, {
+fastify.register(fastifyJwtJwks, {
   jwksUrl: '<JWKS url>',
-  issuer: /<auth0 issuer>/,
-  audience: '<auth0 app audience>'
+  issuer: /<jwt issuer>/,
+  audience: '<jwt app audience>'
 })
-fastify.register(fastifyAuth0Verify, {
+fastify.register(fastifyJwtJwks, {
   jwksUrl: '<JWKS url>',
-  issuer: ['<auth0 issuer>', /<auth0 issuer>/],
-  audience: ['<auth0 app audience>', '<auth0 admin audience>']
+  issuer: ['<jwt issuer>', /<jwt issuer>/],
+  audience: ['<jwt app audience>', '<jwt admin audience>']
 })
-fastify.register(fastifyAuth0Verify, {
+fastify.register(fastifyJwtJwks, {
   jwksUrl: '<JWKS url>',
-  audience: ['<auth0 app audience>', '<auth0 admin audience>']
+  audience: ['<jwt app audience>', '<jwt admin audience>']
 })
 fastify.register(fastifyJWT, {
   secret: '<jwt secret>'
 })
-fastify.register(fastifyAuth0Verify, {
+fastify.register(fastifyJwtJwks, {
   cookie: {
     cookieName: '<cookie>',
     signed: true
   }
 })
-fastify.register(fastifyAuth0Verify, {
+fastify.register(fastifyJwtJwks, {
   jwksUrl: '<JWKS url>',
-  issuer: '<auth0 issuer>',
-  audience: '<auth0 app audience>',
+  issuer: '<jwt issuer>',
+  audience: '<jwt app audience>',
   formatUser: () => ({ foo: 'bar' })
 })
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "fastify-auth0-verify",
+  "name": "fastify-jwt-jwks",
   "version": "1.1.1",
   "description": "Auth0 verification plugin for Fastify",
   "author": "NearForm Ltd",
-  "homepage": "https://github.com/nearform/fastify-auth0-verify",
+  "homepage": "https://github.com/nearform/fastify-jwt-jwks",
   "contributors": [
     {
       "name": "Paolo Insogna",
@@ -29,10 +29,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nearform/fastify-auth0-verify.git"
+    "url": "git+https://github.com/nearform/fastify-jwt-jwks.git"
   },
   "bugs": {
-    "url": "https://github.com/nearform/fastify-auth0-verify/issues"
+    "url": "https://github.com/nearform/fastify-jwt-jwks/issues"
   },
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fastify-jwt-jwks",
   "version": "1.1.1",
-  "description": "Auth0 verification plugin for Fastify",
+  "description": "JWT JWKS verification plugin for Fastify",
   "author": "NearForm Ltd",
   "homepage": "https://github.com/nearform/fastify-jwt-jwks",
   "contributors": [
@@ -24,8 +24,7 @@
   ],
   "keywords": [
     "fastify",
-    "fastify-plugin",
-    "auth0"
+    "fastify-plugin"
   ],
   "repository": {
     "type": "git",

--- a/test-integration/oauth2-mocked-server.integration.test.js
+++ b/test-integration/oauth2-mocked-server.integration.test.js
@@ -16,18 +16,18 @@ async function buildOAuthServer() {
 async function buildServer({ oAuthServerUrl }) {
   const server = Fastify()
 
-  // Setup fastify-auth0-verify
+  // Setup fastify-jwt-jwks
   await server.register(require('../'), {
     jwksUrl: `${oAuthServerUrl}/jwks`,
     issuer: oAuthServerUrl
   })
 
-  // Setup auth0 protected route
+  // Setup jwt protected route
   server.get('/protected', { preValidation: server.authenticate }, (req, reply) => {
     reply.send({ route: 'Protected route' })
   })
 
-  // Setup auth0 public route
+  // Setup public route
   server.get('/public', (req, reply) => {
     reply.send({ route: 'Public route' })
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -208,7 +208,7 @@ describe('Options parsing', function () {
   it('should enable RS256 when jwksUrl is present', async function () {
     const server = await buildServer({ jwksUrl: 'https://localhost/.well-known/jwks.json' })
 
-    expect(server.auth0Verify.verify.algorithms).toEqual(['RS256'])
+    expect(server.jwtJwks.verify.algorithms).toEqual(['RS256'])
 
     server.close()
   })
@@ -216,7 +216,7 @@ describe('Options parsing', function () {
   it('should enable HS256 when the secret is present', async function () {
     const server = await buildServer({ secret: 'secret' })
 
-    expect(server.auth0Verify.verify.algorithms).toEqual(['HS256'])
+    expect(server.jwtJwks.verify.algorithms).toEqual(['HS256'])
 
     server.close()
   })
@@ -224,7 +224,7 @@ describe('Options parsing', function () {
   it('should enable both algorithms is both options are present', async function () {
     const server = await buildServer({ jwksUrl: 'https://localhost/.well-known/jwks.json', secret: 'secret' })
 
-    expect(server.auth0Verify.verify.algorithms).toEqual(['RS256', 'HS256'])
+    expect(server.jwtJwks.verify.algorithms).toEqual(['RS256', 'HS256'])
 
     server.close()
   })


### PR DESCRIPTION
### Introduction
Functionality is unchanged. Focus has been on reformatting variable and function names, tests and docs to reflect new package name. 

**Changes**

- Replaces package name in readme with updated package name 
- Replaces package name in package.json with updated package name, and updated package description
- Replaces package name in tests with updated package name
- Updated CLI example with renamed arguments
- Updates Fastify plugin initialisation to use updated package name
- Updates Fastify decorators to use new plugin name
- Rewrites exposed type declarations to reflect new package name
- Replaces plugin decorator usage in tests with updated decorator name

**Notes** 

The auth0 specific tests and relevant environment variables should be moved to the new auth0 specific repository when the new wrapper package is created. 

There was a suggestion in [this comment](https://github.com/nearform/fastify-auth0-verify/issues/224#issuecomment-1511282412) that the exposed `auth0Verify` and `auth0VerifySecretsCache` Fastify decorators may no longer need to be exposed in this package. They are used internally however so a more involved refactor would be required to remove them. They have so far just been renamed to reflect the new package name. 