### PR TITLE
feat: Add exports for the uninitialised plugin fn to enable wrapping with different options

### DIFF
--- a/index.js
+++ b/index.js
@@ -221,3 +221,5 @@ function fastifyJwtJwks(instance, options, done) {
 }
 
 module.exports = fastifyPlugin(fastifyJwtJwks, { name: 'fastify-jwt-jwks', fastify: '4.x' })
+module.exports.default = fastifyJwtJwks
+module.exports.fastifyJwtJwks = fastifyJwtJwks


### PR DESCRIPTION
### Introduction

Taking inspiration from https://github.com/fastify/fastify-jwt/blob/master/jwt.js#L542 and https://github.com/fastify/fastify-mongodb/blob/master/index.js#LL85C1-L85C23 to export uninitialised plugin function so that it can be initialised elsewhere with different options.