### PR TITLE
chore: handle invalid token used with RS256 algorithm

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,9 @@ function getSecret(request, reply, cb) {
 
       // If the algorithm is not using RS256, the encryption key is jwt client secret
       if (header.alg.startsWith('HS')) {
+        if (!request.jwtJwks.secret) {
+          throw new Unauthorized(errorMessages.invalidAlgorithm)
+        }
         return cb(null, request.jwtJwks.secret)
       }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -702,6 +702,21 @@ describe('RS256 JWT token validation', function () {
     })
   })
 
+  it('should reject an invalid token', async function () {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/verify',
+      headers: { Authorization: `Bearer ${tokens.hs256Valid}` }
+    })
+
+    expect(response.statusCode).toEqual(401)
+    expect(response.json()).toEqual({
+      statusCode: 401,
+      error: 'Unauthorized',
+      message: 'Unsupported token.'
+    })
+  })
+
   it('should reject a token when is not possible to retrieve the JWK set due to a HTTP error', async function () {
     nock.cleanAll()
 


### PR DESCRIPTION
This handles cases where a HS256 token is passed as an header while the server is configured for RS256.
fixes https://github.com/nearform/fastify-auth0-verify/issues/317