### PR TITLE
feat(options): support namespacing of plugin decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vscode
 package-lock.json
 .env
+.idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ All contributions should fit the [standard](https://github.com/standard/standard
 You can test this by running:
 
 ```
-npm lint
+npm run lint
 npm test
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Welcome to fastify-auth0-verify!
+# Welcome to fastify-jwt-jwks!
 
-Please take a second to read over this before opening an issue. Providing complete information upfront will help us address any issue (and ship new features!) faster.
+Please take a second to read this over before opening an issue. Providing complete information up front will help us address any issue (and ship new features!) faster.
 
-We greatly appreciate bug fixes, documentation improvements and new features, however when contributing a new major feature, it is a good idea to idea to first open an issue, to make sure the feature it fits with the goal of the project, so we don't waste your or our time.
+We greatly appreciate bug fixes, documentation improvements and new features, however when contributing a new major feature, it is a good idea to first open an issue, to make sure the feature fits with the goal of the project, so we don't waste your or our time.
 
 ## Bug Reports
 
@@ -12,7 +12,7 @@ A perfect bug report would have the following:
 2. Details on what versions of node and XZY you are using (`node -v`).
 3. A simple repeatable test case for us to run. Please try to run through it 2-3 times to ensure it is completely repeatable.
 
-We would like to avoid issues that require a follow up questions to identify the bug. These follow ups are difficult to do unless we have a repeatable test case.
+We would like to avoid issues that require follow up questions to identify the bug. These follow ups are difficult to do unless we have a repeatable test case.
 
 ## For Developers
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,34 @@ await server.register(require('fastify-jwt-jwks'), {
 })
 ```
 
+You can also use the `namespace` option to apply this plugin multiple times to the same Fastify instance, in order to perform JWT verification with different JWKs URLs:
+
+```js
+await server.register(require('fastify-jwt-jwks'), {
+  jwksUrl: '<JWKS url>',
+  audience: '<app audience>'
+})
+
+await server.register(require('fastify-jwt-jwks'), {
+  jwksUrl: '<JWKS url 2>',
+  audience: '<app audience 2>',
+  namespace: 'newToken'
+})
+
+server.get('/verify',
+  {
+    preValidation: async function (request, reply) {
+      try {
+        await server.authenticate()
+      } catch (err) {
+        await server.newTokenAuthenticate()
+      }
+    }
+  },
+  (request, reply) => { reply.send(request.user) }
+)
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Register as a plugin, providing one or more of the following options:
 - `cookie`: Used to indicate that the token can be passed using cookie, instead of the Authorization header.
   - `cookieName`: The name of the cookie.
   - `signed`: Indicates whether the cookie is signed or not. If set to `true`, the JWT will be verified using the unsigned value.
+- `namespace`: A string used to namespace the decorators of this plugin. This is to allow this plugin to be applied multiple times to a single Fastify instance. See the description of the [namespace parameter](https://github.com/fastify/fastify-jwt?tab=readme-ov-file#namespace) in @fastify/jwt.
 
 Since this plugin is based on the [@fastify/jwt](https://www.npmjs.com/package/@fastify/jwt) `verify`, it is also possibile to pass the options documented [here](https://github.com/fastify/fastify-jwt#verify), see the example below.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,11 @@ export interface FastifyJwtJwksOptions {
    * You may customize the request.user object setting a custom sync function as parameter:
    */
   readonly formatUser?: (payload: SignPayloadType) => UserType
+  /**
+   * A string used to namespace the decorators of this plugin. This is to allow this plugin to be applied multiple times
+   * to a single Fastify instance. See the description of the namespace parameter in @fastify/jwt.
+   */
+  readonly namespace?: string
 }
 
 export interface JwtJwks extends Pick<FastifyJwtJwksOptions, 'jwksUrl' | 'audience' | 'secret'> {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -929,7 +929,7 @@ describe('RS256 JWT token validation', function () {
 describe('Server configured with the namespace option', function () {
   let server
 
-  afterAll(() => {
+  afterEach(() => {
     server.close()
     nock.cleanAll()
     nock.enableNetConnect()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -194,8 +194,8 @@ async function buildServer(options) {
 
   server.get('/decode', async req => {
     return {
-      regular: await req.jwtVerify(),
-      full: await req.jwtVerify({ decode: { complete: true } })
+      regular: await req.jwtDecode(),
+      full: await req.jwtDecode({ decode: { complete: true } })
     }
   })
 


### PR DESCRIPTION
Closes https://github.com/nearform/fastify-jwt-jwks/issues/18

Add support for the `namespace` option when creating this plugin, similar to the option provided by `@fastify/jwt`. This will allow consumers to apply this plugin more than once to the same Fastify instance without creating decorator name collisions.

The code changes look larger than they actually are, because I had to move the `getSecret()` and `authenticate()` function implementations to inside the plugin definition, in order to have access to the namespaced function names. The actual implementations of these functions have remained unchanged. I suggest reviewing the code changes while hiding whitespace changes.

I added one test to ensure that providing the namespace option to the plugin applies decorators with the correct names. I also wanted to add a test to ensure that the plugin still functioned correctly when decoding/verifying JWTs and the namespace option is provided, but doing so felt like adding duplicate code in the test.