### PR TITLE
fix: update authenticate type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ export interface JwtJwks extends Pick<FastifyJwtJwksOptions, 'jwksUrl' | 'audien
   }
 }
 
-export type Authenticate = (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+export type Authenticate = (request: FastifyRequest) => Promise<void>
 
 /**
  * JWT JWKS verification plugin for Fastify, internally uses @fastify/jwt and jsonwebtoken.


### PR DESCRIPTION
I appears the authenticate method changed contract in this PR:
https://github.com/nearform/fastify-jwt-jwks/pull/34/files

But the type was never updated to reflect the change.