### PR TITLE
chore: Remove spurious file likely committed by mistake

### DIFF
--- a/=11.5.1
+++ b/=11.5.1
@@ -1,5 +1,0 @@
-
-removed 9 packages, and changed 42 packages in 6s
-
-25 packages are looking for funding
-  run `npm fund` for details


### PR DESCRIPTION
The repo had a file named `=11.5.1` containing the output of an npm command. It's likely the result of a bad npm command that instead of installing a dependency at the 11.5.1 version only run a regular install and saved the output to the file. The file was then mistakenly committed.

Fixes #59 