### PR TITLE
fix: support FastifyInstance.jwt.verify

### DIFF
--- a/error-messages.js
+++ b/error-messages.js
@@ -1,0 +1,13 @@
+'use strict'
+
+module.exports = {
+  badHeaderFormat: 'Authorization header should be in format: Bearer [token].',
+  expiredToken: 'Expired token.',
+  invalidAlgorithm: 'Unsupported token.',
+  invalidToken: 'Invalid token.',
+  jwksHttpError: 'Unable to get the JWS due to a HTTP error',
+  missingHeader: 'Missing Authorization HTTP header.',
+  missingKey: 'Missing Key: Public key must be provided',
+  missingOptions: 'Please provide at least one of the "jwksUrl" or "secret" options.',
+  unexpectedContext: 'Unexpected context: getSecret called outside known fastify contexts.'
+}

--- a/get-header.js
+++ b/get-header.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { Unauthorized, InternalServerError } = require('http-errors')
+
+const errorMessages = require('./error-messages')
+
+function getHeader(requestOrToken, verifyFunctionName, decodeFunctionName) {
+  const isRequest = typeof requestOrToken[verifyFunctionName] === 'function'
+
+  if (isRequest) {
+    return requestOrToken[decodeFunctionName]({ decode: { complete: true } })
+      .then(decoded => decoded.header)
+      .catch(() => {
+        throw new Unauthorized(errorMessages.invalidToken)
+      })
+  } else {
+    const isDecodedToken = !!requestOrToken.header
+    if (isDecodedToken) {
+      return Promise.resolve(requestOrToken.header)
+    } else {
+      return Promise.reject(new InternalServerError(errorMessages.unexpectedContext))
+    }
+  }
+}
+
+module.exports = getHeader

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ const errorMessages = {
   jwksHttpError: 'Unable to get the JWS due to a HTTP error',
   missingHeader: 'Missing Authorization HTTP header.',
   missingKey: 'Missing Key: Public key must be provided',
-  missingOptions: 'Please provide at least one of the "jwksUrl" or "secret" options.'
+  missingOptions: 'Please provide at least one of the "jwksUrl" or "secret" options.',
+  unexpectedContext: 'Unexpected context: getSecret called outside known fastify contexts.'
 }
 
 const fastifyJwtErrors = [
@@ -152,22 +153,48 @@ function fastifyJwtJwks(instance, options, done) {
     const verifyFunctionName = namespace ? `${namespace}JwtVerify` : 'jwtVerify'
     const authenticateMethodName = namespace ? `${namespace}Authenticate` : 'authenticate'
     const jwksOptionsName = namespace ? `${namespace}JwtJwks` : 'jwtJwks'
-    const secretsCacheName = namespace ? `${namespace}JwtJwksSecretsCache` : 'jwtJwksSecretsCache'
 
-    function getSecret(request, reply, cb) {
-      request[decodeFunctionName]({ decode: { complete: true } })
-        .then(decoded => {
-          const { header } = decoded
+    function getHeader(requestOrToken) {
+      const isRequest = typeof requestOrToken[verifyFunctionName] === 'function'
+
+      if (isRequest) {
+        return requestOrToken[decodeFunctionName]({ decode: { complete: true } })
+          .then(decoded => decoded.header)
+          .catch(() => {
+            throw new Unauthorized(errorMessages.invalidToken)
+          })
+      } else {
+        const isDecodedToken = !!requestOrToken.header
+        if (isDecodedToken) {
+          return Promise.resolve(requestOrToken.header)
+        } else {
+          throw new InternalServerError(errorMessages.unexpectedContext)
+        }
+      }
+    }
+
+    function getSecret(requestOrToken, reply, cb) {
+      if (cb === undefined) {
+        cb = reply
+        reply = null
+      }
+
+      // due to a bug in @fastify/jwt, the getSecret function is called with two different signatures
+      // either with a fastify request object or with a decoded token,
+      // getHeader handles both cases and extracts the header
+      // see https://github.com/fastify/fastify-jwt/issues/388
+      getHeader(requestOrToken)
+        .then(header => {
           // If the algorithm is not using RS256, the encryption key is jwt client secret
           if (header.alg.startsWith('HS')) {
-            if (!request[jwksOptionsName].secret) {
+            if (!instance[jwksOptionsName].secret) {
               throw new Unauthorized(errorMessages.invalidAlgorithm)
             }
-            return cb(null, request[jwksOptionsName].secret)
+            return cb(null, instance[jwksOptionsName].secret)
           }
 
           // If the algorithm is RS256, get the key remotely using a well-known URL containing a JWK set
-          getRemoteSecret(request[jwksOptionsName].jwksUrl, header.alg, header.kid, request[secretsCacheName])
+          getRemoteSecret(instance[jwksOptionsName].jwksUrl, header.alg, header.kid, cache)
             .then(key => cb(null, key))
             .catch(cb)
         })
@@ -214,13 +241,9 @@ function fastifyJwtJwks(instance, options, done) {
       getter: () => jwtJwksOptions
     })
 
+    // Create a cache or a fake cache
     const cache =
       ttl > 0 ? new NodeCache({ stdTTL: ttl }) : { get: () => undefined, set: () => false, close: () => undefined }
-
-    // Create a cache or a fake cache
-    instance.decorateRequest(secretsCacheName, {
-      getter: () => cache
-    })
 
     instance.addHook('onClose', () => cache.close())
 

--- a/index.js
+++ b/index.js
@@ -6,19 +6,10 @@ const fastifyJwt = require('@fastify/jwt')
 const NodeCache = require('node-cache')
 const { createPublicKey } = require('node:crypto')
 
-const forbiddenOptions = ['algorithms']
+const errorMessages = require('./error-messages')
+const getHeader = require('./get-header')
 
-const errorMessages = {
-  badHeaderFormat: 'Authorization header should be in format: Bearer [token].',
-  expiredToken: 'Expired token.',
-  invalidAlgorithm: 'Unsupported token.',
-  invalidToken: 'Invalid token.',
-  jwksHttpError: 'Unable to get the JWS due to a HTTP error',
-  missingHeader: 'Missing Authorization HTTP header.',
-  missingKey: 'Missing Key: Public key must be provided',
-  missingOptions: 'Please provide at least one of the "jwksUrl" or "secret" options.',
-  unexpectedContext: 'Unexpected context: getSecret called outside known fastify contexts.'
-}
+const forbiddenOptions = ['algorithms']
 
 const fastifyJwtErrors = [
   ['Format is Authorization: Bearer \\[token\\]', errorMessages.badHeaderFormat],
@@ -154,25 +145,6 @@ function fastifyJwtJwks(instance, options, done) {
     const authenticateMethodName = namespace ? `${namespace}Authenticate` : 'authenticate'
     const jwksOptionsName = namespace ? `${namespace}JwtJwks` : 'jwtJwks'
 
-    function getHeader(requestOrToken) {
-      const isRequest = typeof requestOrToken[verifyFunctionName] === 'function'
-
-      if (isRequest) {
-        return requestOrToken[decodeFunctionName]({ decode: { complete: true } })
-          .then(decoded => decoded.header)
-          .catch(() => {
-            throw new Unauthorized(errorMessages.invalidToken)
-          })
-      } else {
-        const isDecodedToken = !!requestOrToken.header
-        if (isDecodedToken) {
-          return Promise.resolve(requestOrToken.header)
-        } else {
-          throw new InternalServerError(errorMessages.unexpectedContext)
-        }
-      }
-    }
-
     function getSecret(requestOrToken, reply, cb) {
       if (cb === undefined) {
         cb = reply
@@ -183,7 +155,7 @@ function fastifyJwtJwks(instance, options, done) {
       // either with a fastify request object or with a decoded token,
       // getHeader handles both cases and extracts the header
       // see https://github.com/fastify/fastify-jwt/issues/388
-      getHeader(requestOrToken)
+      getHeader(requestOrToken, verifyFunctionName, decodeFunctionName)
         .then(header => {
           // If the algorithm is not using RS256, the encryption key is jwt client secret
           if (header.alg.startsWith('HS')) {

--- a/test/get-header.test.js
+++ b/test/get-header.test.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const { describe, test } = require('node:test')
+const getHeader = require('../get-header')
+
+describe('getHeader', function () {
+  test('should extract the header from a request object', async function (t) {
+    const request = {
+      jwtVerify: function () {},
+      jwtDecode: function () {
+        return Promise.resolve({ header: { alg: 'RS256', kid: 'KEY' } })
+      }
+    }
+
+    const header = await getHeader(request, 'jwtVerify', 'jwtDecode')
+
+    t.assert.deepStrictEqual(header, { alg: 'RS256', kid: 'KEY' })
+  })
+
+  test('should throw Unauthorized when request decode fails', async function (t) {
+    const request = {
+      jwtVerify: function () {},
+      jwtDecode: function () {
+        return Promise.reject(new Error('decode error'))
+      }
+    }
+
+    await t.assert.rejects(() => getHeader(request, 'jwtVerify', 'jwtDecode'), {
+      message: 'Invalid token.',
+      statusCode: 401
+    })
+  })
+
+  test('should extract the header from a decoded token', async function (t) {
+    const header = await getHeader({ header: { alg: 'RS256', kid: 'KEY' } }, 'jwtVerify', 'jwtDecode')
+
+    t.assert.deepStrictEqual(header, { alg: 'RS256', kid: 'KEY' })
+  })
+
+  test('should extract the header from a decoded token with HS256', async function (t) {
+    const header = await getHeader({ header: { alg: 'HS256', typ: 'JWT' } }, 'jwtVerify', 'jwtDecode')
+
+    t.assert.deepStrictEqual(header, { alg: 'HS256', typ: 'JWT' })
+  })
+
+  test('should reject with InternalServerError for unexpected context', async function (t) {
+    await t.assert.rejects(() => getHeader({}, 'jwtVerify', 'jwtDecode'), {
+      message: 'Unexpected context: getSecret called outside known fastify contexts.',
+      statusCode: 500
+    })
+  })
+
+  test('should reject with InternalServerError for null input', async function (t) {
+    await t.assert.rejects(() => getHeader({ header: null }, 'jwtVerify', 'jwtDecode'), {
+      message: 'Unexpected context: getSecret called outside known fastify contexts.',
+      statusCode: 500
+    })
+  })
+
+  test('should use custom namespace function names', async function (t) {
+    const request = {
+      customJwtVerify: function () {},
+      customJwtDecode: function () {
+        return Promise.resolve({ header: { alg: 'RS256', kid: 'NS-KEY' } })
+      }
+    }
+
+    const header = await getHeader(request, 'customJwtVerify', 'customJwtDecode')
+
+    t.assert.deepStrictEqual(header, { alg: 'RS256', kid: 'NS-KEY' })
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -586,6 +586,15 @@ describe('HS256 JWT token validation', function () {
       message: 'Authorization token is invalid: The token signature is invalid.'
     })
   })
+
+  test('should support jwt.verify on fastify instance', async function (t) {
+    const payload = await server.jwt.verify(tokens.hs256Valid)
+    t.assert.deepStrictEqual(payload, {
+      admin: true,
+      name: 'John Doe',
+      sub: '1234567890'
+    })
+  })
 })
 
 describe('RS256 JWT token validation', function () {
@@ -957,6 +966,16 @@ describe('RS256 JWT token validation', function () {
       message: 'Missing Key: Public key must be provided'
     })
   })
+
+  test('should support jwt.verify on fastify instance', async function (t) {
+    const payload = await server.jwt.verify(tokens.rs256Valid)
+    t.assert.deepStrictEqual(payload, {
+      admin: true,
+      iss: 'https://localhost/',
+      name: 'John Doe',
+      sub: '1234567890'
+    })
+  })
 })
 
 describe('Server configured with the namespace option', function () {
@@ -975,11 +994,9 @@ describe('Server configured with the namespace option', function () {
     t.assert.deepStrictEqual(server.hasDecorator('authenticate'), false)
     t.assert.deepStrictEqual(server.hasDecorator('jwtJwks'), false)
     t.assert.deepStrictEqual(server.hasRequestDecorator('jwtJwks'), false)
-    t.assert.deepStrictEqual(server.hasRequestDecorator('jwtJwksSecretsCache'), false)
     t.assert.deepStrictEqual(server.hasDecorator('testAuthenticate'), true)
     t.assert.deepStrictEqual(server.hasDecorator('testJwtJwks'), true)
     t.assert.deepStrictEqual(server.hasRequestDecorator('testJwtJwks'), true)
-    t.assert.deepStrictEqual(server.hasRequestDecorator('testJwtJwksSecretsCache'), true)
   })
 })
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -231,6 +231,11 @@ async function buildServer(options) {
     }
   })
 
+  server.get('/sign', { preValidation: server.authenticate }, async (req, reply) => {
+    const token = await reply.jwtSign(req.user, { noTimestamp: true })
+    return reply.send({ token })
+  })
+
   await server.listen({ port: 0 })
 
   return server
@@ -594,6 +599,17 @@ describe('HS256 JWT token validation', function () {
       name: 'John Doe',
       sub: '1234567890'
     })
+  })
+
+  test('should support signing', async function (t) {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/sign',
+      headers: { Authorization: `Bearer ${tokens.hs256Valid}` }
+    })
+
+    t.assert.deepStrictEqual(response.statusCode, 200)
+    t.assert.deepStrictEqual(response.json().token, tokens.hs256Valid)
   })
 })
 
@@ -975,6 +991,17 @@ describe('RS256 JWT token validation', function () {
       name: 'John Doe',
       sub: '1234567890'
     })
+  })
+
+  test('should not support signing', async function (t) {
+    const response = await server.inject({
+      method: 'GET',
+      url: '/sign',
+      headers: { Authorization: `Bearer ${tokens.rs256Valid}` }
+    })
+
+    // public / private key pairs aren't supported for signing
+    t.assert.deepStrictEqual(response.statusCode, 500)
   })
 })
 


### PR DESCRIPTION
Due to a bug in @fastify/jwt, getSecret might be called with two different signatures, depending on whether a request context exists.
This commit introduce a workaround so that FastifyInstance.jwt.verify will still work. A better solution can be implemented once @fastify/jwt fixes their issue (see https://github.com/fastify/fastify-jwt/issues/388)

I'm also removing the request decoration that exposes the cache. That doesn't need to be publicly accessible.
The cache attribute is not documented, but since it was previously exposed, it might be considered a breaking change.
If preferable, I can re-introduce it and move the removal to a different PR.

Fixes #54