### PR TITLE
fix: include error-messages.js and get-header.js in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "error-messages.js",
+    "get-header.js"
   ],
   "scripts": {
     "test": "node --test",


### PR DESCRIPTION
## Summary
- The `files` whitelist in `package.json` only listed `index.js` and `index.d.ts`, but `index.js` requires `./error-messages` and `./get-header`. Those two source files exist in the repo but were stripped from the npm tarball for v3.0.0 and v3.0.1.
- Result: every install of v3.0.x throws `Cannot find module './error-messages'` at require time. Reproduces in `fastify-auth0-verify` tests, which depend on this package.
- Fix: add both files to the `files` whitelist so they ship with the published package.

## Test plan
- [ ] After merge, cut a v3.0.2 patch release.
- [ ] Verify `npm pack` includes `error-messages.js` and `get-header.js`.
- [ ] Verify `fastify-auth0-verify` test suite passes against v3.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)